### PR TITLE
Fix refresh flash on login

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,10 @@
 </head>
 
 <body>
+    <!-- Loading overlay to prevent flashing content before authentication state is known -->
+    <div id="loadingOverlay" style="display: flex; align-items: center; justify-content: center; position: fixed; inset: 0; background: white; z-index: 9999;">
+        <span>Ładowanie...</span>
+    </div>
     <div class="relative flex size-full min-h-screen flex-col bg-white group/design-root overflow-x-hidden"
         style='--select-button-svg: url("data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2724px%27 height=%2724px%27 fill=%27rgb(115,115,115)%27 viewBox=%270 0 256 256%27%3e%3cpath d=%27M181.66,170.34a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-48-48a8,8,0,0,1,11.32-11.32L128,212.69l42.34-42.35A8,8,0,0,1,181.66,170.34Zm-96-84.68L128,43.31l42.34,42.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48A8,8,0,0,0,85.66,85.66Z%27%3e%3c/path%3e%3c/svg%3e"); font-family: "Plus Jakarta Sans", "Noto Sans", sans-serif;'>
         <div class="layout-container flex h-full grow flex-col">

--- a/main.js
+++ b/main.js
@@ -546,6 +546,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     waitForFirebase(function() {
+        const loadingOverlay = document.getElementById('loadingOverlay');
         // Login/Logout functionality
         const loginBtn = document.getElementById('loginBtn');
         const logoutBtn = document.getElementById('logoutBtn');
@@ -985,6 +986,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     mainContent.style.display = 'block';
                     mainContent.style.opacity = '1';
                 }
+                if (loadingOverlay) loadingOverlay.style.display = 'none';
 
                 // Show main menu link for authenticated users
                 if (mainMenuLink) {
@@ -1030,6 +1032,8 @@ document.addEventListener('DOMContentLoaded', function () {
                         mainContent.style.display = 'none';
                     }
                 }
+
+                if (loadingOverlay) loadingOverlay.style.display = 'none';
 
                 if (userInfo) userInfo.style.display = 'none';
                 if (loginBtn) loginBtn.style.display = 'inline';


### PR DESCRIPTION
## Summary
- add loading overlay to block UI until Firebase auth state is known
- hide overlay once authentication listener fires

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841c390b4688330bcbecd1e882b88a7