### PR TITLE
Improve status filter card styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -280,35 +280,33 @@
                             <!-- Kolorowe karty statusów -->
                             <div id="quickFilters" style="margin: 1.5rem 0;">
                                 <div class="filter-cards-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem;">
-                                    <div class="filter-card status-card" data-filter-type="status" data-filter-value="" 
-                                         style="background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%); border: 2px solid #e2e8f0; padding: 1.25rem; border-radius: 12px; cursor: pointer; transition: all 0.3s ease; display: flex; flex-direction: column; align-items: center; text-align: center; min-height: 90px; justify-content: center;">
+                                    <div class="filter-card status-card" data-filter-type="status" data-filter-value="">
                                         <i class="fas fa-list" style="font-size: 1.75rem; color: #64748b; margin-bottom: 0.5rem;"></i>
                                         <span style="font-weight: 700; color: #334155; font-size: 1rem;">Wszystkie (<span id="totalCount">0</span>)</span>
                                     </div>
                                     
-                                    <div class="filter-card status-card" data-filter-type="status" data-filter-value="Wysłano CV" 
-                                         style="background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 100%); border: 2px solid #3b82f6; padding: 1.25rem; border-radius: 12px; cursor: pointer; transition: all 0.3s ease; display: flex; flex-direction: column; align-items: center; text-align: center; min-height: 90px; justify-content: center;">
+                                    <div class="filter-card status-card" data-filter-type="status" data-filter-value="Wysłano CV">
                                         <i class="fas fa-paper-plane" style="font-size: 1.75rem; color: #2563eb; margin-bottom: 0.5rem;"></i>
                                         <span style="font-weight: 700; color: #1e40af; font-size: 1rem;">Wysłano CV (<span id="sentCount">0</span>)</span>
                                     </div>
                                     
-                                    <div class="filter-card status-card" data-filter-type="status" data-filter-value="Rozmowy" 
-                                         style="background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%); border: 2px solid #f59e0b; padding: 1.25rem; border-radius: 12px; cursor: pointer; transition: all 0.3s ease; display: flex; flex-direction: column; align-items: center; text-align: center; min-height: 90px; justify-content: center;">
+                                    <div class="filter-card status-card" data-filter-type="status" data-filter-value="Rozmowy">
                                         <i class="fas fa-comments" style="font-size: 1.75rem; color: #d97706; margin-bottom: 0.5rem;"></i>
                                         <span style="font-weight: 700; color: #b45309; font-size: 1rem;">Rozmowy (<span id="interviewCount">0</span>)</span>
                                     </div>
                                     
-                                    <div class="filter-card status-card" data-filter-type="status" data-filter-value="Oferty" 
-                                         style="background: linear-gradient(135deg, #d1fae5 0%, #a7f3d0 100%); border: 2px solid #10b981; padding: 1.25rem; border-radius: 12px; cursor: pointer; transition: all 0.3s ease; display: flex; flex-direction: column; align-items: center; text-align: center; min-height: 90px; justify-content: center;">
+                                    <div class="filter-card status-card" data-filter-type="status" data-filter-value="Oferty">
                                         <i class="fas fa-handshake" style="font-size: 1.75rem; color: #059669; margin-bottom: 0.5rem;"></i>
                                         <span style="font-weight: 700; color: #047857; font-size: 1rem;">Oferty (<span id="offerCount">0</span>)</span>
                                     </div>
                                     
-                                    <div class="filter-card status-card" data-filter-type="status" data-filter-value="Odrzucono" 
-                                         style="background: linear-gradient(135deg, #fee2e2 0%, #fecaca 100%); border: 2px solid #ef4444; padding: 1.25rem; border-radius: 12px; cursor: pointer; transition: all 0.3s ease; display: flex; flex-direction: column; align-items: center; text-align: center; min-height: 90px; justify-content: center;">
+                                    <div class="filter-card status-card" data-filter-type="status" data-filter-value="Odrzucono">
                                         <i class="fas fa-times-circle" style="font-size: 1.75rem; color: #dc2626; margin-bottom: 0.5rem;"></i>
                                         <span style="font-weight: 700; color: #b91c1c; font-size: 1rem;">Odrzucono (<span id="rejectedCount">0</span>)</span>
                                     </div>
+                                </div>
+                                <div id="clearStatusFilterContainer" style="margin-top: 0.5rem; display: none; text-align: right;">
+                                    <button id="clearStatusFilter" style="background:none;border:none;color:#2563eb;cursor:pointer;font-size:0.875rem;text-decoration:underline;">Usuń filtr</button>
                                 </div>
                             </div>
 

--- a/main.js
+++ b/main.js
@@ -1174,6 +1174,11 @@ function applyStatusFilter(filterValue) {
     const sortOrder = document.getElementById("sortOrder")?.value || "desc";
     const showArchived = document.getElementById("showArchived")?.checked || false;
     loadApplications(getFilters(), showArchived, sortOrder);
+
+    const clearContainer = document.getElementById('clearStatusFilterContainer');
+    if (clearContainer) {
+        clearContainer.style.display = filterValue ? 'block' : 'none';
+    }
 }
 
 // Funkcja do inicjalizacji kolorowych kart filtrów statusów
@@ -1246,6 +1251,14 @@ function initializeQuickFilters() {
         });
     });
 
+    const clearBtn = document.getElementById('clearStatusFilter');
+    if (clearBtn) {
+        clearBtn.addEventListener('click', () => {
+            resetQuickFilters();
+            applyStatusFilter('');
+        });
+    }
+
     console.log('✅ Quick filters setup complete');
 
     // Funkcja do resetowania kart statusów
@@ -1255,6 +1268,11 @@ function initializeQuickFilters() {
             window.filters = {};
         }
         window.filters.status = "";
+
+        const clearContainer = document.getElementById('clearStatusFilterContainer');
+        if (clearContainer) {
+            clearContainer.style.display = 'none';
+        }
 
         document.querySelectorAll('.filter-card[data-filter-type="status"]').forEach(card => {
             card.classList.remove('active');
@@ -1282,12 +1300,16 @@ function initializeQuickFilters() {
             if (statusCard) {
                 statusCard.classList.add('active');
             }
+            const clearContainer = document.getElementById('clearStatusFilterContainer');
+            if (clearContainer) clearContainer.style.display = 'block';
         } else {
             // Aktywuj kartę "Wszystkie aplikacje"
             const allStatusCard = document.querySelector('.filter-card[data-filter-type="status"][data-filter-value=""]');
             if (allStatusCard) {
                 allStatusCard.classList.add('active');
             }
+            const clearContainer = document.getElementById('clearStatusFilterContainer');
+            if (clearContainer) clearContainer.style.display = 'none';
         }
     };
 

--- a/style.css
+++ b/style.css
@@ -810,6 +810,42 @@ body #mainContent .applications-table {
     transform: translateY(-1px) scale(1.01);
 }
 
+/* Default appearance for status filter cards */
+.status-card {
+    background: #f5f5f5;
+    border: 2px solid transparent;
+    padding: 1.25rem;
+    border-radius: 12px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    min-height: 90px;
+    justify-content: center;
+}
+
+.status-card[data-filter-value=""] {
+    border-color: #e2e8f0;
+}
+
+.status-card[data-filter-value="Wysłano CV"] {
+    border-color: #3b82f6;
+}
+
+.status-card[data-filter-value="Rozmowy"] {
+    border-color: #f59e0b;
+}
+
+.status-card[data-filter-value="Oferty"] {
+    border-color: #10b981;
+}
+
+.status-card[data-filter-value="Odrzucono"] {
+    border-color: #ef4444;
+}
+
 .filter-card.active {
     transform: translateY(-2px);
     box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
## Summary
- style status filter cards with grey background and colored borders
- add a button to quickly clear the status filter
- update JS logic to toggle card highlight and show/hide clear filter button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841e50e046c83309619679035a7a333