### PR TITLE
Improve filter controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,9 +305,6 @@
                                         <span style="font-weight: 700; color: #b91c1c; font-size: 1rem;">Odrzucono (<span id="rejectedCount">0</span>)</span>
                                     </div>
                                 </div>
-                                <div id="clearStatusFilterContainer" style="margin-top: 0.5rem; display: none; text-align: right;">
-                                    <button id="clearStatusFilter" style="background:none;border:none;color:#2563eb;cursor:pointer;font-size:0.875rem;text-decoration:underline;">Usuń filtr</button>
-                                </div>
                             </div>
 
                             <!-- Toggle Filters and Sort Buttons -->
@@ -319,6 +316,10 @@
                                 <button id="toggleSort"
                                     class="flex items-center gap-2 text-[#141414] text-lg font-bold leading-tight tracking-[-0.015em] bg-[#f5f5f5] px-4 py-2 rounded-lg border border-[#e5e7eb]">
                                     <i class="fas fa-sort"></i> Sortuj
+                                </button>
+                                <button id="clearAllFilters"
+                                    class="flex items-center gap-2 text-[#141414] text-lg font-bold leading-tight tracking-[-0.015em] bg-[#f5f5f5] px-4 py-2 rounded-lg border border-[#e5e7eb]">
+                                    <i class="fas fa-times"></i> Usuń filtry
                                 </button>
                             </div>
 

--- a/main.js
+++ b/main.js
@@ -945,6 +945,14 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 
+    // Clear all filters functionality
+    const clearAllButton = document.getElementById('clearAllFilters');
+    if (clearAllButton) {
+        clearAllButton.addEventListener('click', function () {
+            clearAllFilters();
+        });
+    }
+
     const sortOrder = document.getElementById('sortOrder')?.value || 'desc';
 
     // Initialize page state immediately and prevent page flashing
@@ -1174,11 +1182,6 @@ function applyStatusFilter(filterValue) {
     const sortOrder = document.getElementById("sortOrder")?.value || "desc";
     const showArchived = document.getElementById("showArchived")?.checked || false;
     loadApplications(getFilters(), showArchived, sortOrder);
-
-    const clearContainer = document.getElementById('clearStatusFilterContainer');
-    if (clearContainer) {
-        clearContainer.style.display = filterValue ? 'block' : 'none';
-    }
 }
 
 // Funkcja do inicjalizacji kolorowych kart filtrów statusów
@@ -1251,13 +1254,6 @@ function initializeQuickFilters() {
         });
     });
 
-    const clearBtn = document.getElementById('clearStatusFilter');
-    if (clearBtn) {
-        clearBtn.addEventListener('click', () => {
-            resetQuickFilters();
-            applyStatusFilter('');
-        });
-    }
 
     console.log('✅ Quick filters setup complete');
 
@@ -1269,10 +1265,6 @@ function initializeQuickFilters() {
         }
         window.filters.status = "";
 
-        const clearContainer = document.getElementById('clearStatusFilterContainer');
-        if (clearContainer) {
-            clearContainer.style.display = 'none';
-        }
 
         document.querySelectorAll('.filter-card[data-filter-type="status"]').forEach(card => {
             card.classList.remove('active');
@@ -1300,16 +1292,12 @@ function initializeQuickFilters() {
             if (statusCard) {
                 statusCard.classList.add('active');
             }
-            const clearContainer = document.getElementById('clearStatusFilterContainer');
-            if (clearContainer) clearContainer.style.display = 'block';
         } else {
             // Aktywuj kartę "Wszystkie aplikacje"
             const allStatusCard = document.querySelector('.filter-card[data-filter-type="status"][data-filter-value=""]');
             if (allStatusCard) {
                 allStatusCard.classList.add('active');
             }
-            const clearContainer = document.getElementById('clearStatusFilterContainer');
-            if (clearContainer) clearContainer.style.display = 'none';
         }
     };
 
@@ -1326,6 +1314,25 @@ function getFilters() {
         umowa: document.getElementById('filterUmowa')?.value || "",
         status: window.filters?.status || ""
     };
+}
+
+function clearAllFilters() {
+    ['filterStanowisko', 'filterFirma', 'filterData', 'filterTryb', 'filterRodzaj', 'filterUmowa'].forEach(id => {
+        const el = document.getElementById(id);
+        if (el) el.value = '';
+    });
+
+    const showArchived = document.getElementById('showArchived');
+    if (showArchived) showArchived.checked = false;
+
+    if (typeof resetQuickFilters === 'function') {
+        resetQuickFilters();
+    } else if (window.filters) {
+        window.filters.status = '';
+    }
+
+    const sortOrder = document.getElementById('sortOrder')?.value || 'desc';
+    loadApplications(getFilters(), showArchived?.checked || false, sortOrder);
 }
 //# sourceMappingURL=app.js.map
 

--- a/style.css
+++ b/style.css
@@ -812,8 +812,9 @@ body #mainContent .applications-table {
 
 /* Default appearance for status filter cards */
 .status-card {
-    background: #f5f5f5;
-    border: 2px solid transparent;
+    background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+    border: 2px solid #e5e7eb;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
     padding: 1.25rem;
     border-radius: 12px;
     cursor: pointer;


### PR DESCRIPTION
## Summary
- add global "Usuń filtry" button next to sort options
- implement `clearAllFilters` function and hook it up
- modernize default style of status filter tiles
- remove old single-status clear option

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6841e716c00c83309374f03194d3fdcd