### PR TITLE
Fix Firebase init check

### DIFF
--- a/add-application.html
+++ b/add-application.html
@@ -425,7 +425,7 @@
     <!-- Firebase v10 SDK -->
     <script type="module">
         // Firebase v10 imports
-        import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js';
+        import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js';
         import { getFirestore, collection, addDoc, serverTimestamp } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js';
         import { getAuth, onAuthStateChanged, GoogleAuthProvider, signInWithPopup } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
         // Firebase configuration
@@ -440,7 +440,7 @@
         };
 
         // Initialize Firebase
-        const app = initializeApp(firebaseConfig);
+        const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
         const db = getFirestore(app);
         const auth = getAuth(app);
 

--- a/index.html
+++ b/index.html
@@ -875,7 +875,7 @@ $(cat /tmp/form_styles.txt)
         <!-- Firebase v10 SDK -->
         <script type="module">
             // Firebase v10 imports
-            import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js';
+            import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js';
             import { getFirestore, collection, query, where, orderBy, getDocs, doc, getDoc, updateDoc, deleteDoc, onSnapshot } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js';
             import { getAuth, onAuthStateChanged, GoogleAuthProvider, signInWithPopup, signOut } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
 
@@ -891,7 +891,7 @@ $(cat /tmp/form_styles.txt)
             };
 
             // Initialize Firebase
-            const app = initializeApp(firebaseConfig);
+            const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
             const db = getFirestore(app);
             const auth = getAuth(app);
 


### PR DESCRIPTION
## Summary
- avoid duplicate Firebase initialization by checking existing apps before init in **index.html** and **add-application.html**

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841f20f81b083308d036926cdd73c39