### PR TITLE
Fix add application modal visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -524,7 +524,7 @@
         </div>
 
         <!-- Add Application Modal -->
-        <div id="addAppModal" class="modal" style="display: none;">
+        <div id="addAppModal" class="modal">
             <div class="modal-content">
                 <button class="modal-close" onclick="closeAddAppModal()">&times;</button>
                 


### PR DESCRIPTION
## Summary
- remove inline display override from Add Application modal so the button works

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843efb020948330b5fcd30f094287be