### PR TITLE
Fix overlapping form elements

### DIFF
--- a/add-application.html
+++ b/add-application.html
@@ -30,8 +30,8 @@
         }
 
         .back-btn {
-            display: inline-block;
-            margin-bottom: 1.2rem;
+            display: block;
+            margin: 0 0 1.2rem 0;
             color: #141414;
             font-weight: 600;
             text-decoration: none;
@@ -134,18 +134,19 @@
 
         .salary-group {
             display: flex;
+            flex-wrap: wrap;
             gap: 0.5em;
-            align-items: flex-end;
+            align-items: flex-start;
             margin-bottom: 1.4rem;
         }
 
         .salary-group .salary-main {
-            flex: 2;
+            flex: 2 1 150px;
         }
 
         .salary-group .salary-currency,
         .salary-group .salary-type {
-            flex: 1;
+            flex: 1 1 120px;
         }
 
         .salary-group .form-group {
@@ -261,7 +262,7 @@
             .salary-group .salary-main,
             .salary-group .salary-currency,
             .salary-group .salary-type {
-                flex: 1;
+                flex: 1 1 100%;
             }
 
             .salary-group .form-group:not(:first-child) label {

--- a/style.css
+++ b/style.css
@@ -1035,18 +1035,19 @@ body #mainContent .applications-table {
 
         .salary-group {
             display: flex;
+            flex-wrap: wrap;
             gap: 0.5em;
-            align-items: flex-end;
+            align-items: flex-start;
             margin-bottom: 1.4rem;
         }
 
         .salary-group .salary-main {
-            flex: 2;
+            flex: 2 1 150px;
         }
 
         .salary-group .salary-currency,
         .salary-group .salary-type {
-            flex: 1;
+            flex: 1 1 120px;
         }
 
         .salary-group .form-group {
@@ -1161,7 +1162,7 @@ body #mainContent .applications-table {
             .salary-group .salary-main,
             .salary-group .salary-currency,
             .salary-group .salary-type {
-                flex: 1;
+                flex: 1 1 100%;
             }
 
             .salary-group .form-group:not(:first-child) label {


### PR DESCRIPTION
## Summary
- adjust back link layout in add-application page
- improve salary section flex rules for better wrapping

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6843f5a6dac883309d3e54e60756afaa