### PR TITLE
Fix alignment for salary fields

### DIFF
--- a/add-application.html
+++ b/add-application.html
@@ -136,7 +136,7 @@
             display: flex;
             flex-wrap: wrap;
             gap: 0.5em;
-            align-items: flex-start;
+            align-items: flex-end;
             margin-bottom: 1.4rem;
         }
 
@@ -259,6 +259,7 @@
             .salary-group {
                 flex-direction: column;
                 gap: 1rem;
+                align-items: stretch;
             }
 
             .salary-group .salary-main,

--- a/style.css
+++ b/style.css
@@ -666,7 +666,7 @@ body #mainContent .applications-table {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5em;
-    align-items: flex-start;
+    align-items: flex-end;
     margin-bottom: 1.4rem;
 }
 
@@ -738,6 +738,7 @@ body #mainContent .applications-table {
     #editModal .salary-group {
         flex-direction: column;
         gap: 1rem;
+        align-items: stretch;
     }
 
     #editModal .salary-group .salary-main,
@@ -1042,7 +1043,7 @@ body #mainContent .applications-table {
             display: flex;
             flex-wrap: wrap;
             gap: 0.5em;
-            align-items: flex-start;
+            align-items: flex-end;
             margin-bottom: 1.4rem;
         }
 
@@ -1164,6 +1165,7 @@ body #mainContent .applications-table {
             .salary-group {
                 flex-direction: column;
                 gap: 1rem;
+                align-items: stretch;
             }
 
             .salary-group .salary-main,


### PR DESCRIPTION
## Summary
- fix flex alignment for salary inputs on add and edit forms
- ensure small-screen layout uses stretch alignment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843fae559648330896d3cd2f9f704e6