### PR TITLE
Fix alignment of salary fields in edit form

### DIFF
--- a/style.css
+++ b/style.css
@@ -666,7 +666,7 @@ body #mainContent .applications-table {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5em;
-    align-items: flex-end;
+    align-items: flex-start;
     margin-bottom: 1.4rem;
 }
 
@@ -684,9 +684,9 @@ body #mainContent .applications-table {
 }
 
 #editModal .salary-group .form-group:not(:first-child) label {
-    visibility: hidden;
-    margin-bottom: 0;
-    height: 0;
+    visibility: visible;
+    margin-bottom: 0.5rem;
+    height: auto;
 }
 
 #editModal .favorite-checkbox {


### PR DESCRIPTION
## Summary
- adjust the edit modal salary group so all salary-related fields are left aligned

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843fc72936083308e41dee15b77794a