### PR TITLE
Remove unused skip images option

### DIFF
--- a/add-application.html
+++ b/add-application.html
@@ -406,11 +406,6 @@
                         title="Usuń wszystkie zdjęcia">
                         <i class="fas fa-trash"></i> Usuń wszystkie
                     </button>
-                    <button type="button" onclick="skipImages()"
-                        style="background: #6c757d; color: white; border: none; padding: 0.3rem 0.8rem; border-radius: 6px; font-size: 0.9em; cursor: pointer; margin-left: 0.5rem;"
-                        title="Zapisz bez zdjęć">
-                        <i class="fas fa-forward"></i> Pomiń zdjęcia
-                    </button>
                 </div>
             </div>
 
@@ -618,23 +613,8 @@
             updateImagePreview();
         }
 
-        function skipImages() {
-            if (selectedFiles.length > 0) {
-                const confirmSkip = confirm('Czy na pewno chcesz usunąć wszystkie zdjęcia i zapisać aplikację bez nich?');
-                if (confirmSkip) {
-                    clearAllImages();
-                    // Submit form without images
-                    document.getElementById('addApplicationForm').dispatchEvent(new Event('submit'));
-                }
-            } else {
-                alert('Nie ma zdjęć do pominięcia.');
-            }
-        }
 
-        // Make helpers available globally for inline handlers
         window.clearAllImages = clearAllImages;
-        window.skipImages = skipImages;
-
         // Walidacja pól Stanowisko i Firma - tylko litery
         function validateLettersOnly(input) {
             const regex = /[^a-zA-ZąćęłńóśźżĄĆĘŁŃÓŚŹŻ\s]/g;

--- a/add-application.js
+++ b/add-application.js
@@ -183,22 +183,9 @@
             updateImagePreview();
         }
         
-        function skipImages() {
-            if (selectedFiles.length > 0) {
-                const confirmSkip = confirm('Czy na pewno chcesz usunąć wszystkie zdjęcia i zapisać aplikację bez nich?');
-                if (confirmSkip) {
-                    clearAllImages();
-                    // Submit form without images
-                    document.getElementById('addApplicationForm').dispatchEvent(new Event('submit'));
-                }
-            } else {
-                alert('Nie ma zdjęć do pominięcia.');
-            }
-        }
 
         // Make helpers available globally for inline handlers
         window.clearAllImages = clearAllImages;
-        window.skipImages = skipImages;
 
         // Walidacja pól Stanowisko i Firma - tylko litery
         function validateLettersOnly(input) {

--- a/index.html
+++ b/index.html
@@ -673,11 +673,6 @@
                                     title="Usuń wszystkie zdjęcia">
                                     <i class="fas fa-trash"></i> Usuń wszystkie
                                 </button>
-                                <button type="button" onclick="skipImages()"
-                                    style="background: #6c757d; color: white; border: none; padding: 0.3rem 0.8rem; border-radius: 6px; font-size: 0.9em; cursor: pointer; margin-left: 0.5rem;"
-                                    title="Zapisz bez zdjęć">
-                                    <i class="fas fa-forward"></i> Pomiń zdjęcia
-                                </button>
                             </div>
                         </div>
                         <div class="favorite-checkbox">


### PR DESCRIPTION
## Summary
- remove "skip photos" button from add application forms
- delete skipImages helper and export

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684412742d8483308715d6689338850f