### PR TITLE
Add overlay click to close modals

### DIFF
--- a/index.html
+++ b/index.html
@@ -1050,6 +1050,26 @@
                         openAddAppModal();
                     });
                 }
+
+                // Close modals when clicking outside the form
+                const addAppModal = document.getElementById('addAppModal');
+                if (addAppModal) {
+                    addAppModal.addEventListener('click', function (e) {
+                        if (e.target === addAppModal) {
+                            closeAddAppModal();
+                        }
+                    });
+                }
+
+                const editModal = document.getElementById('editModal');
+                if (editModal) {
+                    editModal.addEventListener('click', function (e) {
+                        if (e.target === editModal) {
+                            const closeBtn = document.getElementById('closeEditModal');
+                            if (closeBtn) closeBtn.click();
+                        }
+                    });
+                }
             });
         </script>
 </body>


### PR DESCRIPTION
## Summary
- allow closing Add Application and Edit modals by clicking outside the form

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684413c07f9083308e314faa999dc2ec