### PR TITLE
Handle empty filtered application lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -483,6 +483,7 @@
                                             </tbody>
                                         </table>
                                     </div>
+                                    <div id="noApplicationsMessage" class="py-6 text-center text-gray-500" style="display: none;"></div>
                                 </div>
                             </div>
                         </div> <!-- End mainContent -->

--- a/main.js
+++ b/main.js
@@ -496,14 +496,21 @@ function loadApplications(filters = {}, showArchived = false, sortOrder = 'desc'
         });
 
         const thead = document.querySelector('.applications-table thead');
+        const tableContainer = document.querySelector('#applicationsCard .table-responsive');
+        const messageEl = document.getElementById('noApplicationsMessage');
+
         if (count === 0) {
             if (thead) thead.style.display = 'none';
-            const noRow = document.createElement('tr');
-            const message = filters.status ? 'Brak aplikacji o tym statusie' : 'Brak aplikacji';
-            noRow.innerHTML = `<td colspan="9" class="py-6 text-center text-gray-500">${message}</td>`;
-            tbody.appendChild(noRow);
+            if (tableContainer) tableContainer.style.display = 'none';
+            if (messageEl) {
+                const message = filters.status ? 'Brak aplikacji o tym statusie' : 'Brak aplikacji';
+                messageEl.textContent = message;
+                messageEl.style.display = 'block';
+            }
         } else {
             if (thead) thead.style.display = '';
+            if (tableContainer) tableContainer.style.display = '';
+            if (messageEl) messageEl.style.display = 'none';
         }
 
         document.querySelectorAll('.edit-btn').forEach(btn => {


### PR DESCRIPTION
## Summary
- show a message when no applications match the chosen status filter
- hide the table when there are no rows

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68442b2096d88330b905e92f88aeca68