### PR TITLE
Add icons for salary fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -702,7 +702,7 @@
                             <div class="salary-main" id="addSalaryFields">
                                 <!-- Pojedyncza kwota -->
                                 <div class="form-group" id="addExactSalaryGroup">
-                                    <label for="addWynagrodzenie">Wynagrodzenie</label>
+                                    <label for="addWynagrodzenie"><i class="fas fa-coins"></i> Wynagrodzenie</label>
                                     <input type="number" id="addWynagrodzenie" name="wynagrodzenie" min="0" step="any"
                                         placeholder="np. 8000">
                                 </div>
@@ -721,8 +721,8 @@
                             </div>
 
                             <div class="salary-currency">
-                                <div class="form-group no-icon">
-                                    <label for="addWaluta">Waluta</label>
+                                <div class="form-group">
+                                    <label for="addWaluta"><i class="fas fa-money-bill"></i> Waluta</label>
                                     <select id="addWaluta" name="waluta">
                                         <option value="PLN">PLN</option>
                                         <option value="EUR">EUR</option>
@@ -731,8 +731,8 @@
                                 </div>
                             </div>
                             <div class="salary-type">
-                                <div class="form-group no-icon">
-                                    <label for="addWynRodzaj">Rodzaj</label>
+                                <div class="form-group">
+                                    <label for="addWynRodzaj"><i class="fas fa-percent"></i> Rodzaj</label>
                                     <select id="addWynRodzaj" name="wynRodzaj">
                                         <option value="BRUTTO">BRUTTO</option>
                                         <option value="NETTO">NETTO</option>
@@ -881,7 +881,7 @@
                             <div class="salary-main" id="editSalaryFields">
                                 <!-- Pojedyncza kwota -->
                                 <div class="form-group" id="editExactSalaryGroup">
-                                    <label for="editWynagrodzenie">Wynagrodzenie</label>
+                                    <label for="editWynagrodzenie"><i class="fas fa-coins"></i> Wynagrodzenie</label>
                                     <input type="number" id="editWynagrodzenie" name="wynagrodzenie" min="0" step="any"
                                         placeholder="np. 8000">
                                 </div>
@@ -900,8 +900,8 @@
                             </div>
 
                             <div class="salary-currency">
-                                <div class="form-group no-icon">
-                                    <label for="editWaluta">Waluta</label>
+                                <div class="form-group">
+                                    <label for="editWaluta"><i class="fas fa-money-bill"></i> Waluta</label>
                                     <select id="editWaluta" name="waluta">
                                         <option value="PLN">PLN</option>
                                         <option value="EUR">EUR</option>
@@ -910,8 +910,8 @@
                                 </div>
                             </div>
                             <div class="salary-type">
-                                <div class="form-group no-icon">
-                                    <label for="editWynRodzaj">Rodzaj</label>
+                                <div class="form-group">
+                                    <label for="editWynRodzaj"><i class="fas fa-percent"></i> Rodzaj</label>
                                     <select id="editWynRodzaj" name="wynRodzaj">
                                         <option value="BRUTTO">BRUTTO</option>
                                         <option value="NETTO">NETTO</option>


### PR DESCRIPTION
## Summary
- add matching icons for salary amount, currency and net/gross fields in both add and edit forms

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68540f973a708330867592ffeef36ad6